### PR TITLE
Fb/cds upgrade improvements

### DIFF
--- a/src/submodules/capMultitenancy.js
+++ b/src/submodules/capMultitenancy.js
@@ -184,9 +184,6 @@ const _cdsUpgrade = async (
       url: cfRouteUrl,
       pathname: isMtxs ? `/-/cds/jobs/pollJob(ID='${jobId}')` : `/mtx/v1/model/status/${jobId}`,
       auth: { token: await context.getCachedUaaToken() },
-      headers: {
-        "X-Cf-App-Instance": `${cfAppGuid}:${appInstance}`,
-      },
     });
     const pollJobResponseData = await _safeMaterializeJson(pollJobResponse, "poll job");
 
@@ -205,9 +202,6 @@ const _cdsUpgrade = async (
               url: cfRouteUrl,
               pathname: `/-/cds/jobs/pollTask(ID='${taskId}')`,
               auth: { token: await context.getCachedUaaToken() },
-              headers: {
-                "X-Cf-App-Instance": `${cfAppGuid}:${appInstance}`,
-              },
             });
             const pollTaskResponseData = await _safeMaterializeJson(pollTaskResponse, "poll task");
             const { status, error } = pollTaskResponseData || {};


### PR DESCRIPTION
Following the new mtxs upgrade problems, we added some more resilience and clarifying logging.

cds upgrade will now:
- show one-line task progress summary after every poll
- stop the upgrade of no task progress change happens after 30min
- avoid individual task status calls for the final summary and use the `tasks` field of the job status instead, this requires a recent mtxs version on the server
