### PR TITLE
Fb/retry header handling

### DIFF
--- a/src/shared/request.js
+++ b/src/shared/request.js
@@ -204,13 +204,7 @@ const _request = async ({
       const doLogAttempt = attempt > 0 || !doStopRetry;
       const correlationHeader = CORRELATION_HEADERS_RECEIVER_PRECEDENCE.find((header) => response.headers.has(header));
       logRequestId ??= doLogAttempt && LogRequestId.next();
-      const retryLogPart = doStopRetry
-        ? []
-        : [
-            retryHeaderSleepTime !== null
-              ? `retrying in ${sleepTime / 1000}sec (Retry-After)`
-              : `retrying in ${sleepTime / 1000}sec`,
-          ];
+      const retryLogPart = doStopRetry ? [] : [`retrying in ${sleepTime / 1000}sec`];
       const logParts = [
         ...(doLogAttempt ? [`[req-${logRequestId} ${attempt + 1}/${RETRY_MAX_ATTEMPTS}]`] : []),
         `${_method} ${decodeURI(_url.href)} ${response.status} ${response.statusText}`,

--- a/src/shared/request.js
+++ b/src/shared/request.js
@@ -12,6 +12,9 @@ const HTTP_TOO_MANY_REQUESTS = 429;
 const RETRY_POLL_FREQUENCIES = [6000, 12000, 24000, 48000];
 const RETRY_STOP_MARKER = -1;
 const RETRY_SLEEP_TIMES = [].concat(RETRY_POLL_FREQUENCIES, [RETRY_STOP_MARKER]);
+const RETRY_AFTER_HEADER = "Retry-After";
+// NOTE: cap Retry-After to keep a misbehaving server from stalling us indefinitely
+const RETRY_AFTER_MAX_MS = 5 * 60 * 1000;
 
 const ENV = Object.freeze({
   CORRELATION: "MTX_CORRELATION",
@@ -52,6 +55,39 @@ const _doStopRetry = (mode, response) => {
       throw new Error("unknown retry mode");
   }
 };
+
+// Parse a Retry-After header value per RFC 9110 / MDN: either a non-negative integer
+// number of seconds (delta-seconds), or an HTTP-date. Returns milliseconds to wait,
+// or null when absent, malformed, non-positive, or beyond RETRY_AFTER_MAX_MS.
+const _parseRetryAfter = (headerValue, nowMs = Date.now()) => {
+  if (typeof headerValue !== "string") {
+    return null;
+  }
+  const trimmed = headerValue.trim();
+  if (!trimmed) {
+    return null;
+  }
+  let waitMs;
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number(trimmed);
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      return null;
+    }
+    waitMs = seconds * 1000;
+  } else {
+    const dateMs = Date.parse(trimmed);
+    if (!Number.isFinite(dateMs)) {
+      return null;
+    }
+    waitMs = dateMs - nowMs;
+    if (waitMs <= 0) {
+      return null;
+    }
+  }
+  return Math.min(waitMs, RETRY_AFTER_MAX_MS);
+};
+
+const _getRetryAfterSleep = (response) => _parseRetryAfter(response.headers?.get?.(RETRY_AFTER_HEADER));
 
 class LogRequestId {
   static #id = 0;
@@ -152,22 +188,28 @@ const _request = async ({
 
   let response;
   let logRequestId;
-  for (const [attempt, sleepTime] of RETRY_SLEEP_TIMES.entries()) {
+  for (const [attempt, fixedSleepTime] of RETRY_SLEEP_TIMES.entries()) {
     const startTime = Date.now();
     response = await fetchlib(_url, _options);
     const responseTime = Date.now() - startTime;
-    const doStopRetry = sleepTime === RETRY_STOP_MARKER || _doStopRetry(retryMode, response);
+    const doStopRetry = fixedSleepTime === RETRY_STOP_MARKER || _doStopRetry(retryMode, response);
+    const retryAfterSleepTime = doStopRetry ? null : _getRetryAfterSleep(response);
+    const sleepTime = retryAfterSleepTime ?? fixedSleepTime;
     if (logged) {
       const doLogAttempt = attempt > 0 || !doStopRetry;
       const correlationHeader = CORRELATION_HEADERS_RECEIVER_PRECEDENCE.find((header) => response.headers.has(header));
       logRequestId ??= doLogAttempt && LogRequestId.next();
+      const retryHint =
+        retryAfterSleepTime !== null
+          ? `retrying in ${sleepTime / 1000}sec (Retry-After)`
+          : `retrying in ${sleepTime / 1000}sec`;
       const logParts = [
         ...(doLogAttempt ? [`[req-${logRequestId} ${attempt + 1}/${RETRY_SLEEP_TIMES.length}]`] : []),
         `${_method} ${decodeURI(_url.href)} ${response.status} ${response.statusText}`,
         ...(showCorrelation
           ? [`(${responseTime}ms, ${correlationHeader}: ${response.headers.get(correlationHeader)})`]
           : [`(${responseTime}ms)`]),
-        ...(doStopRetry ? [] : [`retrying in ${sleepTime / 1000}sec`]),
+        ...(doStopRetry ? [] : [retryHint]),
       ];
       logger.info(logParts.join(" "));
     }
@@ -196,5 +238,6 @@ module.exports = {
   request,
   _: {
     LogRequestId,
+    _parseRetryAfter,
   },
 };

--- a/src/shared/request.js
+++ b/src/shared/request.js
@@ -8,10 +8,9 @@ const { fail } = require("./error");
 const { Logger } = require("./logger");
 
 const HTTP_TOO_MANY_REQUESTS = 429;
-// NOTE: These times add up to 90sec in total and give an exponential falloff
-const RETRY_POLL_FREQUENCIES = [6000, 12000, 24000, 48000];
-const RETRY_STOP_MARKER = -1;
-const RETRY_SLEEP_TIMES = [].concat(RETRY_POLL_FREQUENCIES, [RETRY_STOP_MARKER]);
+// NOTE: With 4 attempts and 6sec base, the times add up to 90sec in total
+const RETRY_SLEEP_BASE = 6000;
+const RETRY_MAX_ATTEMPTS = 4;
 const RETRY_AFTER_HEADER = "Retry-After";
 // NOTE: cap Retry-After to keep a misbehaving server from stalling us indefinitely
 const RETRY_AFTER_MAX_MS = 5 * 60 * 1000;
@@ -56,6 +55,8 @@ const _doStopRetry = (mode, response) => {
   }
 };
 
+const _retryfixedSleepTime = (attempt) => RETRY_SLEEP_BASE * Math.pow(2, attempt);
+
 // Parse a Retry-After header value per RFC 9110 / MDN: either a non-negative integer
 // number of seconds (delta-seconds), or an HTTP-date. Returns milliseconds to wait,
 // or null when absent, malformed, non-positive, or beyond RETRY_AFTER_MAX_MS.
@@ -87,7 +88,7 @@ const _parseRetryAfter = (headerValue, nowMs = Date.now()) => {
   return Math.min(waitMs, RETRY_AFTER_MAX_MS);
 };
 
-const _getRetryAfterSleep = (response) => _parseRetryAfter(response.headers?.get?.(RETRY_AFTER_HEADER));
+const _getRetryHeaderSleepTime = (response) => _parseRetryAfter(response.headers?.get?.(RETRY_AFTER_HEADER));
 
 class LogRequestId {
   static #id = 0;
@@ -188,23 +189,23 @@ const _request = async ({
 
   let response;
   let logRequestId;
-  for (const [attempt, fixedSleepTime] of RETRY_SLEEP_TIMES.entries()) {
+  for (let attempt = 0; attempt < RETRY_MAX_ATTEMPTS; attempt++) {
     const startTime = Date.now();
     response = await fetchlib(_url, _options);
     const responseTime = Date.now() - startTime;
-    const doStopRetry = fixedSleepTime === RETRY_STOP_MARKER || _doStopRetry(retryMode, response);
-    const retryAfterSleepTime = doStopRetry ? null : _getRetryAfterSleep(response);
-    const sleepTime = retryAfterSleepTime ?? fixedSleepTime;
+    const doStopRetry = _doStopRetry(retryMode, response);
+    const retryHeaderSleepTime = doStopRetry ? null : _getRetryHeaderSleepTime(response);
+    const sleepTime = retryHeaderSleepTime ?? _retryfixedSleepTime(attempt);
     if (logged) {
       const doLogAttempt = attempt > 0 || !doStopRetry;
       const correlationHeader = CORRELATION_HEADERS_RECEIVER_PRECEDENCE.find((header) => response.headers.has(header));
       logRequestId ??= doLogAttempt && LogRequestId.next();
       const retryHint =
-        retryAfterSleepTime !== null
+        retryHeaderSleepTime !== null
           ? `retrying in ${sleepTime / 1000}sec (Retry-After)`
           : `retrying in ${sleepTime / 1000}sec`;
       const logParts = [
-        ...(doLogAttempt ? [`[req-${logRequestId} ${attempt + 1}/${RETRY_SLEEP_TIMES.length}]`] : []),
+        ...(doLogAttempt ? [`[req-${logRequestId} ${attempt + 1}/${RETRY_MAX_ATTEMPTS}]`] : []),
         `${_method} ${decodeURI(_url.href)} ${response.status} ${response.statusText}`,
         ...(showCorrelation
           ? [`(${responseTime}ms, ${correlationHeader}: ${response.headers.get(correlationHeader)})`]

--- a/src/shared/request.js
+++ b/src/shared/request.js
@@ -8,9 +8,10 @@ const { fail } = require("./error");
 const { Logger } = require("./logger");
 
 const HTTP_TOO_MANY_REQUESTS = 429;
-// NOTE: With 4 attempts and 6sec base, the times add up to 90sec in total
+// NOTE: With 5 attempts and 6sec base, the times add up to 90sec in total.
+//   the final attempt is always stopped and does not add the associated sleep time.
 const RETRY_SLEEP_BASE = 6000;
-const RETRY_MAX_ATTEMPTS = 4;
+const RETRY_MAX_ATTEMPTS = 5;
 const RETRY_AFTER_HEADER = "Retry-After";
 // NOTE: cap Retry-After to keep a misbehaving server from stalling us indefinitely
 const RETRY_AFTER_MAX_MS = 5 * 60 * 1000;
@@ -55,7 +56,7 @@ const _doStopRetry = (mode, response) => {
   }
 };
 
-const _retryfixedSleepTime = (attempt) => RETRY_SLEEP_BASE * Math.pow(2, attempt);
+const _retryFixedSleepTime = (attempt) => RETRY_SLEEP_BASE * Math.pow(2, attempt);
 
 // Parse a Retry-After header value per RFC 9110 / MDN: either a non-negative integer
 // number of seconds (delta-seconds), or an HTTP-date. Returns milliseconds to wait,
@@ -193,24 +194,30 @@ const _request = async ({
     const startTime = Date.now();
     response = await fetchlib(_url, _options);
     const responseTime = Date.now() - startTime;
-    const doStopRetry = _doStopRetry(retryMode, response);
+
+    const isLastAttempt = attempt === RETRY_MAX_ATTEMPTS - 1;
+    const doStopRetry = _doStopRetry(retryMode, response) || isLastAttempt;
     const retryHeaderSleepTime = doStopRetry ? null : _getRetryHeaderSleepTime(response);
-    const sleepTime = retryHeaderSleepTime ?? _retryfixedSleepTime(attempt);
+    const retryFixedSleepTime = doStopRetry ? null : _retryFixedSleepTime(attempt);
+    const sleepTime = retryHeaderSleepTime ?? retryFixedSleepTime;
     if (logged) {
       const doLogAttempt = attempt > 0 || !doStopRetry;
       const correlationHeader = CORRELATION_HEADERS_RECEIVER_PRECEDENCE.find((header) => response.headers.has(header));
       logRequestId ??= doLogAttempt && LogRequestId.next();
-      const retryHint =
-        retryHeaderSleepTime !== null
-          ? `retrying in ${sleepTime / 1000}sec (Retry-After)`
-          : `retrying in ${sleepTime / 1000}sec`;
+      const retryLogPart = doStopRetry
+        ? []
+        : [
+            retryHeaderSleepTime !== null
+              ? `retrying in ${sleepTime / 1000}sec (Retry-After)`
+              : `retrying in ${sleepTime / 1000}sec`,
+          ];
       const logParts = [
         ...(doLogAttempt ? [`[req-${logRequestId} ${attempt + 1}/${RETRY_MAX_ATTEMPTS}]`] : []),
         `${_method} ${decodeURI(_url.href)} ${response.status} ${response.statusText}`,
         ...(showCorrelation
           ? [`(${responseTime}ms, ${correlationHeader}: ${response.headers.get(correlationHeader)})`]
           : [`(${responseTime}ms)`]),
-        ...(doStopRetry ? [] : [retryHint]),
+        ...retryLogPart,
       ];
       logger.info(logParts.join(" "));
     }

--- a/test/shared/request.test.js
+++ b/test/shared/request.test.js
@@ -16,7 +16,7 @@ jest.mock("../../src/shared/static", () => ({
 const {
   request,
   RETRY_MODE,
-  _: { LogRequestId },
+  _: { LogRequestId, _parseRetryAfter },
 } = require("../../src/shared/request");
 
 const { outputFromLogger, MockHeaders } = require("../test-util/static");
@@ -338,5 +338,107 @@ describe("request tests", () => {
     expect(outputFromLoggerWithTimestamps(mockLogger.info.mock.calls)).toMatchInlineSnapshot(
       `"GET https://fake-server.com/path 200 OK (88ms)"`
     );
+  });
+
+  describe("_parseRetryAfter", () => {
+    // NOTE: pinned "now" so HTTP-date cases stay deterministic
+    const nowMs = Date.parse("2026-01-01T00:00:00Z");
+    const secondsInFuture = (n) => new Date(nowMs + n * 1000).toUTCString();
+
+    test.each([
+      ["integer seconds", "10", 10_000],
+      ["integer seconds with surrounding whitespace", "  30  ", 30_000],
+      ["http-date in the future", secondsInFuture(45), 45_000],
+      ["cap enforced on huge integer", "99999", 5 * 60 * 1000],
+      ["cap enforced on far-future http-date", secondsInFuture(60 * 60), 5 * 60 * 1000],
+    ])("valid: %s", (_desc, input, expected) => {
+      expect(_parseRetryAfter(input, nowMs)).toBe(expected);
+    });
+
+    test.each([
+      ["undefined", undefined],
+      ["null", null],
+      ["number instead of string", 10],
+      ["empty string", ""],
+      ["only whitespace", "   "],
+      ["zero seconds", "0"],
+      ["negative-looking (not delta-seconds per RFC, falls to date parse)", "-5"],
+      ["garbage", "soon"],
+      ["http-date in the past", "Wed, 21 Oct 1970 07:28:00 GMT"],
+      ["http-date exactly now", new Date(nowMs).toUTCString()],
+    ])("invalid: %s", (_desc, input) => {
+      expect(_parseRetryAfter(input, nowMs)).toBeNull();
+    });
+  });
+
+  test("Retry-After header overrides fixed backoff on 429", async () => {
+    mockStatic.sleep.mockClear();
+    const withRetryAfter = (value) => ({
+      ...baseTooManyRequestsResponse,
+      headers: new Headers([["Retry-After", value]]),
+    });
+    mockFetchLib.mockReturnValueOnce(withRetryAfter("3"));
+    mockFetchLib.mockReturnValueOnce(withRetryAfter("7"));
+    mockFetchLib.mockReturnValueOnce(baseOkResponse);
+
+    await request({ url: "https://fake-server.com", pathname: "/path" });
+
+    expect(mockStatic.sleep.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          3000,
+        ],
+        [
+          7000,
+        ],
+      ]
+    `);
+    expect(outputFromLoggerWithTimestamps(mockLogger.info.mock.calls)).toMatchInlineSnapshot(`
+      "[req-01 1/5] GET https://fake-server.com/path 429 Too Many Requests (88ms) retrying in 3sec
+      [req-01 2/5] GET https://fake-server.com/path 429 Too Many Requests (88ms) retrying in 7sec
+      [req-01 3/5] GET https://fake-server.com/path 200 OK (88ms)"
+    `);
+  });
+
+  test("invalid Retry-After falls back to fixed backoff", async () => {
+    mockStatic.sleep.mockClear();
+    const withRetryAfter = (value) => ({
+      ...baseTooManyRequestsResponse,
+      headers: new Headers([["Retry-After", value]]),
+    });
+    mockFetchLib.mockReturnValueOnce(withRetryAfter("garbage"));
+    mockFetchLib.mockReturnValueOnce(withRetryAfter(""));
+    mockFetchLib.mockReturnValueOnce(baseOkResponse);
+
+    await request({ url: "https://fake-server.com", pathname: "/path" });
+
+    expect(mockStatic.sleep.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          6000,
+        ],
+        [
+          12000,
+        ],
+      ]
+    `);
+  });
+
+  test("Retry-After is not consulted when we would not retry", async () => {
+    mockStatic.sleep.mockClear();
+    const bad500WithRetryAfter = {
+      ...baseBadRequestResponse,
+      status: 500,
+      statusText: "Internal Server Error",
+      headers: new Headers([["Retry-After", "120"]]),
+    };
+    const headerGetSpy = jest.spyOn(bad500WithRetryAfter.headers, "get");
+    mockFetchLib.mockReturnValueOnce(bad500WithRetryAfter);
+
+    // NOTE: retryMode TOO_MANY_REQUESTS stops on 500 (not 429), so no retry and no header lookup
+    await expect(request({ url: "https://fake-server.com", pathname: "/path" })).rejects.toBeDefined();
+
+    expect(mockStatic.sleep).not.toHaveBeenCalled();
+    expect(headerGetSpy).not.toHaveBeenCalledWith("Retry-After");
   });
 });


### PR DESCRIPTION
Relates to #181

We add the general retry-after header handling to request.

TODO:
- [x] should _doStopRetry react to retry headers? => this is fine as is. the retrymode can be extended as needed when we come across more real use-cases.
- [x] tests
